### PR TITLE
Portability, Readability, Variable storing

### DIFF
--- a/src/operations.rs
+++ b/src/operations.rs
@@ -10,10 +10,11 @@ pub struct OperationController;
 
 impl OperationController {
     // NOTE: no changes so far (`find_toml` is never used)
+    #[allow(dead_code)]
     pub fn find_toml() -> Result<PathBuf, io::Error> {
         match env::current_dir() {
             Ok(root_path) => match root_path.clone().file_name() {
-                Some(dir) => {
+                Some(_) => {
                     match fs::read_dir(root_path.clone()) {
                         Ok(files) => {
                             println!("{:?}", root_path);

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -9,6 +9,7 @@ use colored::Colorize;
 pub struct OperationController;
 
 impl OperationController {
+    // NOTE: no changes so far (`find_toml` is never used)
     pub fn find_toml() -> Result<PathBuf, io::Error> {
         match env::current_dir() {
             Ok(root_path) => match root_path.clone().file_name() {
@@ -48,86 +49,105 @@ impl OperationController {
     }
 
     pub fn compile(root_path: PathBuf) -> Result<(), io::Error> {
-        if root_path.join("src").exists() && root_path.join("out").exists() {
-            let src_path = root_path.join("src");
-            let out_path = root_path.join("out");
+        // define src + out dirs
+        let src_path = root_path.join("src");
+        let out_path = root_path.join("out");
 
-            let status = Command::new("sh")
-                .arg("-c")
-                .arg(format!(
-                    "javac -d {} {}/*.java",
-                    out_path.to_string_lossy(),
-                    src_path.to_string_lossy()
-                ))
-                .status()
-                .expect("Failed to execute javac");
-
-            if status.success() {
-                println!("{}\n", "java project compiled successfully!".green().bold());
-                match Self::run(out_path) {
-                    Ok(_) => {
-                        return Ok(());
-                    }
-                    Err(e) => println!("error: {}", e),
-                }
-            } else {
-                println!("Compilation failed");
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Could not compile the files",
-                ));
-            }
-        }
-
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "Could not find src directory and/or out directory",
-        ))
-    }
-
-    pub fn run(out_path: PathBuf) -> Result<(), io::Error> {
-        let status = Command::new("sh")
-            .arg("-c")
-            .arg(format!(
-                "java -classpath {} Main",
-                out_path.to_string_lossy()
-            ))
-            .status()
-            .expect("Failed to execute java command");
-
-        if status.success() {
-            // println!("{}", "success!\n".green());
-            return Ok(());
-        } else {
+        // if any of them doesn't exists, early returning
+        if [&src_path, &out_path].iter().any(|cond| !cond.exists()) {
             println!("{}", "Compilation failed".red().bold());
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                "Could not run the files",
+                "Couldn't find `src` and/or `out` directory",
             ));
         }
-    }
 
-    //finds the root dir
-    pub fn find() -> Result<PathBuf, io::Error> {
-        match env::current_dir() {
-            Ok(root_path) => match Self::look_for_src(root_path) {
-                Ok(src_path) => return Ok(src_path),
-                Err(e) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("Unable to locate src directory\nerror: {}", e),
-                    ))
-                }
-            },
-            Err(e) => return Err(e),
+        // get java files
+        let java_files: Vec<_> = fs::read_dir(src_path)?
+            .filter_map(|f| f.ok())
+            .filter(|f| f.path().extension().map_or(false, |ext| ext == "java"))
+            .map(|f| f.path())
+            .collect();
+
+        // compile cmd
+        let status = Command::new("javac")
+            .arg("-d")
+            .arg(&out_path)
+            .args(java_files)
+            .status()
+            .expect("Failed to execute javac");
+
+        // if not success, alert + early return
+        if !status.success() {
+            println!("Compilation failed");
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Could not compile the files",
+            ));
         }
-        // Err(io::Error::new(
-        //     io::ErrorKind::Other,
-        //     "Could not run the files",
-        // ))
+
+        // else, print success + run
+        println!("{}\n", "java project compiled successfully!".green().bold());
+        match Self::run(out_path) {
+            Err(e) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("Couldn't run the files.\n{}: {}", "error".red(), e),
+            )),
+            _ => Ok(()),
+        }
     }
 
-    pub fn look_for_src(mut path: PathBuf) -> Result<PathBuf, io::Error> {
+    pub fn run(out_path: PathBuf) -> Result<(), io::Error> {
+        // run cmd
+        let status = Command::new("java")
+            .arg("-classpath")
+            .arg(&out_path)
+            .arg("Main")
+            .status()
+            .expect("Failed to execute java command");
+
+        // return cmd status info
+        if status.success() {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("Couldn't run the {}/Main.class", out_path.to_string_lossy()),
+            ))
+        }
+    }
+
+    pub fn find() -> Result<PathBuf, io::Error> {
+        // if current_dir is err, early returning
+        let abs_path = match env::current_dir() {
+            Ok(p) => p,
+            e => return e,
+        };
+
+        // return src dir looking status
+        match Self::look_for_src(abs_path) {
+            Err(e) => Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("Unable to locate src directory\nerror: {}", e),
+            )),
+            x => x,
+        }
+    }
+
+    pub fn look_for_src(path: PathBuf) -> Result<PathBuf, io::Error> {
+        if path.join("src").exists() {
+            return Ok(path.to_path_buf());
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "Couldn't find src dir at current path",
+            ));
+        }
+
+        // BUG: This is an error prone approach. Considering that I'm not at a
+        // jargo (sub)directory, it will build a new PathBuf recursively until
+        // it raise an error on `path.parent().unwrap()`
+        #[allow(unreachable_code)]
         if path.join("src").exists() {
             return Ok(path.to_path_buf());
         } else {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,6 +1,19 @@
 pub struct Templates;
 use colored::*;
 
+// store command name, alias and description as mod constants
+const COMMAND_ALIASES_DESCS: [(&str, &str, &str); 5] = [
+    ("help", "h", "Lists all commands available"),
+    ("new", "n", "Creates a new java project"),
+    ("run", "r", "Compiles and run your java project"),
+    (
+        "jrun",
+        "j",
+        "Just run the lastest compiled version of your project",
+    ),
+    ("create", "c", "Creates a new class in your java project"),
+];
+
 impl Templates {
     pub fn generate_main() -> String {
         r#"public class Main {
@@ -23,12 +36,16 @@ impl Templates {
     }
     pub fn help() {
         println!("Java's package manager\n");
-        println!("{} {}","Usage:".green().bold(), "jargo [command]\n".cyan());
+        println!("{} {}", "Usage:".green().bold(), "jargo [command]\n".cyan());
         println!("{}", "Commands:".green().bold());
-        println!("   {}      {}", "help, h".cyan(), "Lists all commands available");
-        println!("   {}       {}", "new, n".cyan(), "Creates a new java project");
-        println!("   {}       {}", "run, r".cyan(), "Compiles and run your java project");
-        println!("   {}      {}", "jrun, j".cyan(), "Just run the lastest compiled version of your project");
-        println!("   {}    {}", "create, c".cyan(), "Creates a new class in your java project");
+        for (cmd, alias, desc) in COMMAND_ALIASES_DESCS {
+            println!(
+                "   {}, {}{}{}",
+                cmd.cyan(),
+                alias.cyan(),
+                " ".repeat(10 - cmd.len() - alias.len()),
+                desc
+            );
+        }
     }
 }


### PR DESCRIPTION
## Changes for jargo/port-read-v1 🦀

### Portability

Use `Command::new("java/javac")` instead of `Command::new("sh").arg(...)`. `sh` command can work on some unix OS'es like alpine, but it can fail on Windows if you don't have `sh` shell, or even in unix-sys based on `bash` or `zsh` shell.

> [!NOTE]
>
> If you have `java`/`javac` at your system path, you don't need to worry about which shell you are using 😉

### Readability

Avoid nested `match`/`if`-`else` by using early returning concept. It helps to maintain the code cleaner and more _'understandable'_. Basically:

This:
```rust
impl Person {
    fn can_buy_early_returning(&self, thing_to_buy: impl Buynable) -> bool {
        if self.age < MINIMUM_AGE {
            return false;
        }

        if !thing_to_buy.its_on_sale() {
            return false;
        }

        let price_with_discount =
            thing_to_buy.price() * (1.0 - thing_to_buy.discount_percentage());

        if self.money < price_with_discount {
            return false;
        }

        true
    }
}
```

Is better than this:
```rust
impl Person {
    fn can_buy_this_nested(&self, thing_to_buy: impl Buynable) -> bool {
        if self.age >= MINIMUM_AGE {
            if thing_to_buy.its_on_sale() {
                if self.money
                    < thing_to_buy.price()
                        - (thing_to_buy.price() * thing_to_buy.discount_percentage())
                {
                    true
                } else {
                    false
                }
            } else {
                false
            }
        } else {
            false
        }
    }
}
```

Also, add useful comments + tag messages along the code, like

```rust
fn dangerous_func() {
    let optional_value: Option<i32> = None;
    return;
    // BUG: This will panic, so let's avoid this line, by returning
    // the function (line above)
    println!("{}", optional_value.unwrap());
}
```

### Variable Storing

Instead of using String value as default function argument, let's take a more secure approach by storing the desired values.

Instead of doing this:
```rust
// file path encoding can behave differently from OS to OS
let compiling = Command::new("javac").arg("-d")
                    .arg("out")
                    .arg("src/*.java")
                    .status();
```

We can do this:
```rust
// get all java files
let java_files: Vec<PathBuf> = src_path.files()
                                   .filter(|p| p.extension() == "java")
                                   .collect();

// pass them to the command call
let compiling = Command::new("javac").arg("-d")
                    .arg("out")
                    .args(java_files)
                    .status();
```