### PR TITLE
Args accessing with no "High Severity" errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use std::env;
 use colored::*;
+use std::env;
 use templates::Templates;
 mod creation;
 use creation::*;
@@ -9,11 +9,16 @@ use operations::*;
 //HetzWGA
 
 fn main() -> std::io::Result<()> {
-    let args: Vec<String> = env::args().collect();
+    let args: Vec<String> = env::args().skip(1).collect();
 
-    let flag = &args[1];
+    let subcommand = if let Some(cmd) = args.first() {
+        cmd
+    } else {
+        Templates::help();
+        return Ok(());
+    };
 
-    if flag == "run" || flag == "r"{
+    if subcommand == "run" || subcommand == "r" {
         // match OperationController::find_toml() {
         //     Ok(root_path) => match OperationController::compile(root_path) {
         //         Ok(_) => {}
@@ -28,8 +33,16 @@ fn main() -> std::io::Result<()> {
             },
             Err(e) => println!("error: {}", e),
         }
-    } else if flag == "new" || flag == "n" {
-        let new_dir = &args[2];
+    } else if subcommand == "new" || subcommand == "n" {
+        let new_dir = if let Some(dir) = args.iter().nth(1) {
+            dir
+        } else {
+            println!("{} a new project :^(", "Couldn't create".red());
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "`jargo new` was called but no directory was specified",
+            ));
+        };
 
         match CreationController::create_root_dir(new_dir) {
             Ok(_) => match env::current_dir() {
@@ -41,7 +54,11 @@ fn main() -> std::io::Result<()> {
                         Some(&"Main.java".to_string()),
                     ) {
                         Ok(_path) => {
-                            println!("{} `{}`","Created new application".green().bold(), new_dir.cyan());
+                            println!(
+                                "{} `{}`",
+                                "Created new application".green().bold(),
+                                new_dir.cyan()
+                            );
                         }
                         Err(e) => println!("error: {}", e),
                     }
@@ -50,13 +67,22 @@ fn main() -> std::io::Result<()> {
             },
             Err(e) => println!("error: {}", e),
         };
-    } else if flag == "create" || flag == "c" {
-        let classname = &args[2];
+    } else if subcommand == "create" || subcommand == "c" {
+        let classname = if let Some(class) = args.iter().nth(1) {
+            class
+        } else {
+            println!("{} a new class :^(", "Couldn't create".red());
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "`jargo create` was called but no directory was specified",
+            ));
+        };
+
         match CreationController::create_class(classname) {
-            Ok(_) => println!("{} `{}`","Created class:".green().bold(), classname.cyan()),
+            Ok(_) => println!("{} `{}`", "Created class:".green().bold(), classname.cyan()),
             Err(e) => println!("{}", e),
         }
-    } else if flag == "jrun" || flag == "j" {
+    } else if subcommand == "jrun" || subcommand == "j" {
         match OperationController::find() {
             Ok(path) => {
                 let out_path = path.clone().join("out");
@@ -67,7 +93,7 @@ fn main() -> std::io::Result<()> {
             }
             Err(e) => println!("error: {}", e),
         }
-    } else if flag == "help" || flag == "h" {
+    } else if subcommand == "help" || subcommand == "h" {
         Templates::help();
     } else {
         println!("Unknown command")


### PR DESCRIPTION
## Changes for jargo/vector-access 🦀

### Problem to solve 🪲

Accessing `String` array using `const usize` index can raise an error during runtime. Ex:
```rust
// BUG: fail if env::args() has less than 3 elements
let target_arg: String = std::env::args().collect()[2];
```

### Solution 🔨

Access the array using iterator features (allowing null elements by returning `Option<String>`)
```rust
let target_arg: Option<String> = std::env::args().nth(2);

if target_arg.is_none() {
    // TODO: handle error
    ...
}
```

### What was changed 🔬

- **Args getting 🔍**
  Skip the first command line argument by using `skip()` function (it's the binary path. Useless for this context);

- **Get the first subcommand + help by default 🆘**
  Instead of getting subcommand with `array indexing`, lets use `nth()` function. Also, we'll implement the _"Help by default"_ when no args given;

- **Get the subcommand args by the same way as above ⛏️**
  Get arg by using `nth()` function. If arg is missing, report error with `println!()` function + early returning a `std::io::Error`.